### PR TITLE
Refactor signaling

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,6 @@ func main() {
 		MaxAge:           12 * time.Hour,
 	}))
 	apiRouter := router.Group("/api")
-	room.RegisterRouter(apiRouter.Group("/room"))
+	room.RegisterRouter(apiRouter.Group("/room"), room.NewHub())
 	router.Run()
 }

--- a/room/models.go
+++ b/room/models.go
@@ -8,7 +8,9 @@ import (
 type hub struct {
 	sigSrv signaling.Server
 }
-type HubModel interface {
+
+// Hub manages rooms
+type Hub interface {
 	roomList() []string
 	roomInfo(hubID string) (*signaling.HubInfo, error)
 	roomCreate(hubID string) *signaling.Hub
@@ -32,7 +34,7 @@ func (r hub) handleWS(router *gin.RouterGroup, baseURL string) {
 }
 
 // NewHub creates a new hub model
-func NewHub() HubModel {
+func NewHub() Hub {
 	return hub{sigSrv: signaling.New()}
 
 }

--- a/room/models.go
+++ b/room/models.go
@@ -1,13 +1,38 @@
 package room
 
 import (
+	"github.com/gin-gonic/gin"
 	"github.com/ray1422/YAM-api/room/signaling"
 )
 
-func hubList() []string {
-	return signaling.HubList()
+type hub struct {
+	sigSrv signaling.Server
+}
+type HubModel interface {
+	roomList() []string
+	roomInfo(hubID string) (*signaling.HubInfo, error)
+	roomCreate(hubID string) *signaling.Hub
+	handleWS(router *gin.RouterGroup, baseURL string)
 }
 
-func hubInfo(hubID string) (*signaling.HubInfo, error) {
-	return signaling.HubInfoByID(hubID)
+func (r hub) roomList() []string {
+	return r.sigSrv.RoomList()
+}
+
+func (r hub) roomInfo(hubID string) (*signaling.HubInfo, error) {
+	return r.sigSrv.RoomInfoByID(hubID)
+}
+
+func (r hub) roomCreate(hubID string) *signaling.Hub {
+	return r.sigSrv.RoomCreate(hubID)
+}
+
+func (r hub) handleWS(router *gin.RouterGroup, baseURL string) {
+	r.sigSrv.RoomWSHandler(router, baseURL)
+}
+
+// NewHub creates a new hub model
+func NewHub() HubModel {
+	return hub{sigSrv: signaling.New()}
+
 }

--- a/room/models.go
+++ b/room/models.go
@@ -1,33 +1,13 @@
 package room
 
 import (
-	"errors"
-
 	"github.com/ray1422/YAM-api/room/signaling"
 )
 
 func hubList() []string {
-	signaling.GlobalHubsLock.RLock()
-	hubsID := []string{}
-	for c := range signaling.Hubs {
-		hubsID = append(hubsID, c)
-	}
-	signaling.GlobalHubsLock.RUnlock()
-	return hubsID
+	return signaling.HubList()
 }
 
 func hubInfo(hubID string) (*signaling.HubInfo, error) {
-	signaling.GlobalHubsLock.RLock()
-	defer signaling.GlobalHubsLock.RUnlock()
-	h, ok := signaling.Hubs[hubID]
-	if !ok {
-		return nil, errors.New("hub not found")
-	}
-	datChan := make(chan *signaling.HubInfo, 1)
-	h.RequestInfoChan <- &datChan
-	hubDat := <-datChan
-	if hubDat == nil {
-		return nil, errors.New("hub has been closed")
-	}
-	return hubDat, nil
+	return signaling.HubInfoByID(hubID)
 }

--- a/room/models.go
+++ b/room/models.go
@@ -12,8 +12,8 @@ type hub struct {
 // Hub manages rooms
 type Hub interface {
 	roomList() []string
-	roomInfo(hubID string) (*signaling.HubInfo, error)
-	roomCreate(hubID string) *signaling.Hub
+	roomInfo(hubID string) (*signaling.RoomInfo, error)
+	roomCreate(hubID string) *signaling.Room
 	handleWS(router *gin.RouterGroup, baseURL string)
 }
 
@@ -21,11 +21,11 @@ func (r hub) roomList() []string {
 	return r.sigSrv.RoomList()
 }
 
-func (r hub) roomInfo(hubID string) (*signaling.HubInfo, error) {
+func (r hub) roomInfo(hubID string) (*signaling.RoomInfo, error) {
 	return r.sigSrv.RoomInfoByID(hubID)
 }
 
-func (r hub) roomCreate(hubID string) *signaling.Hub {
+func (r hub) roomCreate(hubID string) *signaling.Room {
 	return r.sigSrv.RoomCreate(hubID)
 }
 

--- a/room/models_test.go
+++ b/room/models_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestListRoom(t *testing.T) {
+	room := hub{sigSrv: signaling.New()}
 	// create hubs
-	signaling.CreateHub("www")
-	signaling.CreateHub("asdf")
+	room.sigSrv.RoomCreate("www")
+	room.sigSrv.RoomCreate("asdf")
 
-	ss := hubList()
+	ss := room.roomList()
 	assert.ElementsMatch(t, []string{"www", "asdf"}, ss)
 }

--- a/room/models_test.go
+++ b/room/models_test.go
@@ -1,72 +1,17 @@
 package room
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
-	"github.com/gorilla/websocket"
 	"github.com/ray1422/YAM-api/room/signaling"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListRoom(t *testing.T) {
-	// create a hub
-	signaling.GlobalHubsLock.Lock()
-	signaling.Hubs["www"] = signaling.CreateHub("www")
-	signaling.Hubs["asdf"] = signaling.CreateHub("asdf")
-	signaling.GlobalHubsLock.Unlock()
+	// create hubs
+	signaling.CreateHub("www")
+	signaling.CreateHub("asdf")
+
 	ss := hubList()
 	assert.ElementsMatch(t, []string{"www", "asdf"}, ss)
-}
-
-func TestRoomInfo(t *testing.T) {
-	s := httptest.NewServer(http.HandlerFunc(echo))
-	defer s.Close()
-	// Convert http://127.0.0.1 to ws://127.0.0.1
-	u := "ws" + strings.TrimPrefix(s.URL, "http")
-
-	// Connect to the server
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	defer ws.Close()
-	signaling.GlobalHubsLock.Lock()
-	signaling.Hubs["www"] = signaling.CreateHub("www")
-	signaling.Hubs["asdf"] = signaling.CreateHub("asdf")
-	signaling.GlobalHubsLock.Unlock()
-	h := signaling.Hubs["www"]
-	c := h.NewClient(ws)
-	h.RegisterChan <- c
-	hi, err := hubInfo("www")
-	assert.Nil(t, err)
-	assert.Equal(t, hi.ID, "www")
-	assert.Equal(t, 1, len(hi.Members))
-	h.UnregisterChan <- c
-	hi, err = hubInfo("www")
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(hi.Members))
-
-}
-
-var upgrader = websocket.Upgrader{}
-
-func echo(w http.ResponseWriter, r *http.Request) {
-	c, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return
-	}
-	defer c.Close()
-	for {
-		mt, message, err := c.ReadMessage()
-		if err != nil {
-			break
-		}
-		err = c.WriteMessage(mt, message)
-		if err != nil {
-			break
-		}
-	}
 }

--- a/room/room_test.go
+++ b/room/room_test.go
@@ -54,7 +54,7 @@ func testJoinClient(wsURL string, joinURL string) (*websocket.Conn, error) {
 func TestListHub(t *testing.T) {
 	roomName := "adsf"
 	router := gin.Default()
-	RegisterRouter(router.Group("/api/room"))
+	RegisterRouter(router.Group("/api/room"), hub{sigSrv: signaling.New()})
 	s := httptest.NewServer(router)
 	defer s.Close()
 	joinU := url.URL{Scheme: "http", Host: strings.TrimPrefix(s.URL, "http://"), Path: "/api/room/" + roomName + "/"}

--- a/room/room_test.go
+++ b/room/room_test.go
@@ -70,7 +70,7 @@ func TestListHub(t *testing.T) {
 	assert.Nil(t, err)
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.Nil(t, err)
-	info := signaling.HubInfo{}
+	info := signaling.RoomInfo{}
 	assert.Nil(t, json.Unmarshal(body, &info))
 	assert.Equal(t, roomName, info.ID)
 	assert.Equal(t, 2, len(info.Members))

--- a/room/signaling/client_test.go
+++ b/room/signaling/client_test.go
@@ -97,7 +97,7 @@ func TestClientRegisterTimeout(t *testing.T) {
 func TestClientRegisterHubClosed(t *testing.T) {
 	h := CreateHub("asdf")
 	c := h.NewClient(newWS())
-	h.cleanTicker.Reset(0)
+	h.cleanTicker.Reset(1)
 	time.Sleep(5500 * time.Millisecond)
 	assert.NotNil(t, c.conn.WriteJSON(&map[string]string{}))
 }

--- a/room/signaling/client_test.go
+++ b/room/signaling/client_test.go
@@ -87,7 +87,7 @@ func TestClientProvideDat(t *testing.T) {
 			assert.Equal(t, client.id, obj.RemoteID)
 		}
 	}
-	client.hub.UnregisterChan <- client
+	client.room.UnregisterChan <- client
 }
 
 func TestClientRegisterTimeout(t *testing.T) {
@@ -97,7 +97,7 @@ func TestClientRegisterTimeout(t *testing.T) {
 	time.Sleep(5500 * time.Millisecond)
 	assert.NotNil(t, c.conn.WriteJSON(&map[string]string{}))
 }
-func TestClientRegisterHubClosed(t *testing.T) {
+func TestClientRegisterRoomClosed(t *testing.T) {
 	s := new()
 	h := s.RoomCreate("asdf")
 	c := h.NewClient(newWS())

--- a/room/signaling/client_test.go
+++ b/room/signaling/client_test.go
@@ -21,7 +21,9 @@ func TestParseAction(t *testing.T) {
 
 }
 func TestClientProvideDat(t *testing.T) {
-	client := CreateHub("www").NewClient(nil)
+	s := new()
+
+	client := s.RoomCreate("www").NewClient(nil)
 	fmt.Println("client ID:", client.id)
 	{
 		_, err := client.provideData([]byte(`{"remote_id":"www"}`), Offer)
@@ -89,13 +91,15 @@ func TestClientProvideDat(t *testing.T) {
 }
 
 func TestClientRegisterTimeout(t *testing.T) {
-	h := CreateHub("asdf")
+	s := new()
+	h := s.RoomCreate("asdf")
 	c := h.NewClient(newWS())
 	time.Sleep(5500 * time.Millisecond)
 	assert.NotNil(t, c.conn.WriteJSON(&map[string]string{}))
 }
 func TestClientRegisterHubClosed(t *testing.T) {
-	h := CreateHub("asdf")
+	s := new()
+	h := s.RoomCreate("asdf")
 	c := h.NewClient(newWS())
 	h.cleanTicker.Reset(1)
 	time.Sleep(5500 * time.Millisecond)

--- a/room/signaling/hub_exported.go
+++ b/room/signaling/hub_exported.go
@@ -2,30 +2,30 @@ package signaling
 
 import "errors"
 
-// RoomList list all hubs
+// RoomList list all rooms
 func (s *server) RoomList() []string {
-	s.hubLock.RLock()
-	defer s.hubLock.RUnlock()
-	hubsID := []string{}
-	for c := range s.hubs {
-		hubsID = append(hubsID, c)
+	s.roomsLock.RLock()
+	defer s.roomsLock.RUnlock()
+	roomsID := []string{}
+	for c := range s.rooms {
+		roomsID = append(roomsID, c)
 	}
-	return hubsID
+	return roomsID
 }
 
-// RoomInfoByID returns HubInfo
-func (s *server) RoomInfoByID(hubID string) (*HubInfo, error) {
-	s.hubLock.RLock()
-	defer s.hubLock.RUnlock()
-	h, ok := s.hubs[hubID]
+// RoomInfoByID returns RoomInfo by roomID
+func (s *server) RoomInfoByID(roomID string) (*RoomInfo, error) {
+	s.roomsLock.RLock()
+	defer s.roomsLock.RUnlock()
+	r, ok := s.rooms[roomID]
 	if !ok {
-		return nil, errors.New("hub not found")
+		return nil, errors.New("room not found")
 	}
-	datChan := make(chan *HubInfo, 1)
-	h.RequestInfoChan <- &datChan
-	hubDat := <-datChan
-	if hubDat == nil {
-		return nil, errors.New("hub has been closed")
+	datChan := make(chan *RoomInfo, 1)
+	r.RequestInfoChan <- &datChan
+	roomDat := <-datChan
+	if roomDat == nil {
+		return nil, errors.New("room has been closed")
 	}
-	return hubDat, nil
+	return roomDat, nil
 }

--- a/room/signaling/hub_exported.go
+++ b/room/signaling/hub_exported.go
@@ -1,0 +1,31 @@
+package signaling
+
+import "errors"
+
+// HubList list all hubs
+func HubList() []string {
+	globalHubsLock.RLock()
+	hubsID := []string{}
+	for c := range hubs {
+		hubsID = append(hubsID, c)
+	}
+	globalHubsLock.RUnlock()
+	return hubsID
+}
+
+// HubInfoByID returns HubInfo
+func HubInfoByID(hubID string) (*HubInfo, error) {
+	globalHubsLock.RLock()
+	defer globalHubsLock.RUnlock()
+	h, ok := hubs[hubID]
+	if !ok {
+		return nil, errors.New("hub not found")
+	}
+	datChan := make(chan *HubInfo, 1)
+	h.RequestInfoChan <- &datChan
+	hubDat := <-datChan
+	if hubDat == nil {
+		return nil, errors.New("hub has been closed")
+	}
+	return hubDat, nil
+}

--- a/room/signaling/hub_exported.go
+++ b/room/signaling/hub_exported.go
@@ -2,22 +2,22 @@ package signaling
 
 import "errors"
 
-// HubList list all hubs
-func HubList() []string {
-	globalHubsLock.RLock()
+// RoomList list all hubs
+func (s *server) RoomList() []string {
+	s.hubLock.RLock()
+	defer s.hubLock.RUnlock()
 	hubsID := []string{}
-	for c := range hubs {
+	for c := range s.hubs {
 		hubsID = append(hubsID, c)
 	}
-	globalHubsLock.RUnlock()
 	return hubsID
 }
 
-// HubInfoByID returns HubInfo
-func HubInfoByID(hubID string) (*HubInfo, error) {
-	globalHubsLock.RLock()
-	defer globalHubsLock.RUnlock()
-	h, ok := hubs[hubID]
+// RoomInfoByID returns HubInfo
+func (s *server) RoomInfoByID(hubID string) (*HubInfo, error) {
+	s.hubLock.RLock()
+	defer s.hubLock.RUnlock()
+	h, ok := s.hubs[hubID]
 	if !ok {
 		return nil, errors.New("hub not found")
 	}

--- a/room/signaling/hub_test.go
+++ b/room/signaling/hub_test.go
@@ -1,9 +1,13 @@
 package signaling
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,12 +17,37 @@ func TestClientJoinAfterHubClose(t *testing.T) {
 	t.Cleanup(func() {
 		cleanerTimeout = oldCleanerTimeout
 	})
-	GlobalHubsLock.Lock()
-	Hubs["www"] = CreateHub("www")
-	hub := Hubs["www"]
-	GlobalHubsLock.Unlock()
+	hubs["www"] = CreateHub("www")
+	hub := hubs["www"]
 	c1 := hub.NewClient(nil)
 	time.Sleep(300 * time.Millisecond) // make it timeout
 	assert.NotNil(t, c1.registerClient([]byte(`{"token": "www"}`)))
 	time.Sleep(300 * time.Millisecond) // make it timeout
+}
+
+func TestHubInfo(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(echo))
+	defer s.Close()
+	// Convert http://127.0.0.1 to ws://127.0.0.1
+	u := "ws" + strings.TrimPrefix(s.URL, "http")
+
+	// Connect to the server
+	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer ws.Close()
+	CreateHub("www")
+	CreateHub("asdf")
+	h := hubs["www"]
+	c := h.NewClient(ws)
+	h.RegisterChan <- c
+	hi, err := HubInfoByID("www")
+	assert.Nil(t, err)
+	assert.Equal(t, hi.ID, "www")
+	assert.Equal(t, 1, len(hi.Members))
+	h.UnregisterChan <- c
+	hi, err = HubInfoByID("www")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(hi.Members))
 }

--- a/room/signaling/room_test.go
+++ b/room/signaling/room_test.go
@@ -11,21 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClientJoinAfterHubClose(t *testing.T) {
+func TestClientJoinAfterRoomClose(t *testing.T) {
 	s := New()
 	oldCleanerTimeout := cleanerTimeout
 	cleanerTimeout = 100 * time.Millisecond // mock
 	t.Cleanup(func() {
 		cleanerTimeout = oldCleanerTimeout
 	})
-	hub := s.RoomCreate("www")
-	c1 := hub.NewClient(nil)
+	room := s.RoomCreate("www")
+	c1 := room.NewClient(nil)
 	time.Sleep(300 * time.Millisecond) // make it timeout
 	assert.NotNil(t, c1.registerClient([]byte(`{"token": "www"}`)))
 	time.Sleep(300 * time.Millisecond) // make it timeout
 }
 
-func TestHubInfo(t *testing.T) {
+func TestRoomInfo(t *testing.T) {
 	sigSrv := New()
 	s := httptest.NewServer(http.HandlerFunc(echo))
 	defer s.Close()

--- a/room/signaling/signaling.go
+++ b/room/signaling/signaling.go
@@ -1,0 +1,36 @@
+package signaling
+
+import (
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+type server struct {
+	hubs    map[string]*Hub
+	hubLock sync.RWMutex
+}
+
+// Server is the signaling server holding all the hubs
+type Server interface {
+	RoomList() []string
+	RoomInfoByID(hubID string) (*HubInfo, error)
+	// RoomCreate(roomID string) *Hub
+	RoomCreate(roomID string) *Hub
+	RoomWSHandler(router *gin.RouterGroup, baseURL string)
+}
+
+var _ Server = (*server)(nil)
+
+// New creates a new signaling server
+func New() Server {
+	return &server{
+		hubs: map[string]*Hub{},
+	}
+}
+
+func new() *server {
+	return &server{
+		hubs: map[string]*Hub{},
+	}
+}

--- a/room/signaling/signaling.go
+++ b/room/signaling/signaling.go
@@ -7,16 +7,16 @@ import (
 )
 
 type server struct {
-	hubs    map[string]*Hub
-	hubLock sync.RWMutex
+	rooms     map[string]*Room
+	roomsLock sync.RWMutex
 }
 
-// Server is the signaling server holding all the hubs
+// Server is the signaling server holding all the rooms
 type Server interface {
 	RoomList() []string
-	RoomInfoByID(hubID string) (*HubInfo, error)
-	// RoomCreate(roomID string) *Hub
-	RoomCreate(roomID string) *Hub
+	RoomInfoByID(roomID string) (*RoomInfo, error)
+	// RoomCreate(roomID string) *Room
+	RoomCreate(roomID string) *Room
 	RoomWSHandler(router *gin.RouterGroup, baseURL string)
 }
 
@@ -25,12 +25,12 @@ var _ Server = (*server)(nil)
 // New creates a new signaling server
 func New() Server {
 	return &server{
-		hubs: map[string]*Hub{},
+		rooms: map[string]*Room{},
 	}
 }
 
 func new() *server {
 	return &server{
-		hubs: map[string]*Hub{},
+		rooms: map[string]*Room{},
 	}
 }

--- a/room/signaling/signaling_test.go
+++ b/room/signaling/signaling_test.go
@@ -26,9 +26,9 @@ type listClientResponse struct {
 
 func TestMultiClients(t *testing.T) {
 	s := new()
-	hub := s.RoomCreate("www")
-	c1 := hub.NewClient(nil)
-	c2 := hub.NewClient(nil)
+	room := s.RoomCreate("www")
+	c1 := room.NewClient(nil)
+	c2 := room.NewClient(nil)
 	assert.NotNil(t, c1, c2)
 	token := jwt.New(48 * time.Hour)
 	token.Payload["room_id"] = "www"
@@ -56,7 +56,7 @@ func TestMultiClients(t *testing.T) {
 	dat, err := c1.provideData([]byte(`{"remote_id":"`+c2.id+`", "data": "yet_another_data"}`), Offer)
 	assert.Equal(t, c2.id, dat.toID)
 	assert.Nil(t, err)
-	c1.hub.simpleChan <- dat
+	c1.room.simpleChan <- dat
 	receiveBytes := <-c2.send
 	aw = actionWrapper{}
 	err = json.Unmarshal(receiveBytes, &aw)
@@ -213,7 +213,7 @@ func TestWithRealConn(t *testing.T) {
 
 	<-done
 	<-done
-	// TODO get information from hub.
+	// TODO get information from room.
 	c1.Close()
 	leaveSig := struct {
 		Action string `json:"action"`
@@ -226,9 +226,9 @@ func TestWithRealConn(t *testing.T) {
 	assert.Equal(t, "client_event", leaveSig.Action)
 	assert.NotEmpty(t, leaveSig.Data.RemoteID)
 	assert.Equal(t, "leave", leaveSig.Data.Event)
-	ch := make(chan *HubInfo, 1)
+	ch := make(chan *RoomInfo, 1)
 
-	s.hubs[roomName].RequestInfoChan <- &ch
+	s.rooms[roomName].RequestInfoChan <- &ch
 
 	info := <-ch
 	assert.Equal(t, 1, len(info.Members))

--- a/room/signaling/signaling_test.go
+++ b/room/signaling/signaling_test.go
@@ -25,11 +25,7 @@ type listClientResponse struct {
 }
 
 func TestMultiClients(t *testing.T) {
-
-	GlobalHubsLock.Lock()
-	Hubs["www"] = CreateHub("www")
-	hub := Hubs["www"]
-	GlobalHubsLock.Unlock()
+	hub := CreateHub("www")
 	c1 := hub.NewClient(nil)
 	c2 := hub.NewClient(nil)
 	assert.NotNil(t, c1, c2)
@@ -81,7 +77,7 @@ func TestWithRealConn(t *testing.T) {
 	done := make(chan bool)
 	router := gin.Default()
 	var c1ID string
-	RoomWS(router.Group("/api/room"), "/")
+	RoomWSHandler(router.Group("/api/room"), "/")
 	s := httptest.NewServer(router)
 	defer s.Close()
 
@@ -104,7 +100,7 @@ func TestWithRealConn(t *testing.T) {
 	msg := "yet_another_data"
 	defer c2.Close()
 
-	// readloop for c1
+	// read loop for c1
 	go func(t *testing.T, msg string) {
 		token := jwt.New(48 * time.Hour)
 		token.Payload["room_id"] = roomName
@@ -230,14 +226,10 @@ func TestWithRealConn(t *testing.T) {
 	assert.Equal(t, "leave", leaveSig.Data.Event)
 	ch := make(chan *HubInfo, 1)
 
-	Hubs[roomName].RequestInfoChan <- &ch
+	hubs[roomName].RequestInfoChan <- &ch
 
-	// time.Sleep(1 * time.Second)
-	// GlobalHubsLock.RLock()
-	// h, ok := Hubs[roomName]
 	info := <-ch
 	assert.Equal(t, 1, len(info.Members))
-	// GlobalHubsLock.Unlock()
 
 }
 

--- a/room/signaling/views.go
+++ b/room/signaling/views.go
@@ -11,26 +11,25 @@ import (
 )
 
 var (
-	// TODO use sync.Map
-	Hubs           = map[string]*Hub{}
-	GlobalHubsLock sync.RWMutex
+	hubs           = map[string]*Hub{}
+	globalHubsLock sync.RWMutex
 )
 
-// RoomWS RoomWS
-func RoomWS(router *gin.RouterGroup, baseURL string) {
+// RoomWSHandler RoomWSHandler
+func RoomWSHandler(router *gin.RouterGroup, baseURL string) {
 	router.GET(baseURL+":room_id/ws/", func(c *gin.Context) {
 		roomID := c.Param("room_id")
-		GlobalHubsLock.Lock()
-		defer GlobalHubsLock.Unlock()
-		if Hubs[roomID] == nil {
+		globalHubsLock.Lock()
+		defer globalHubsLock.Unlock()
+		if hubs[roomID] == nil {
 			if roomID == "neo" && os.Getenv("DEBUG") != "" { // TODO temp hardcoded
-				Hubs[roomID] = CreateHub(roomID)
+				hubs[roomID] = CreateHub(roomID)
 			} else {
 				c.JSON(http.StatusUnauthorized, nil)
 				return
 			}
 		}
-		hub := Hubs[roomID]
+		hub := hubs[roomID]
 
 		upgrader := websocket.Upgrader{
 			ReadBufferSize:  8192,

--- a/room/signaling/views.go
+++ b/room/signaling/views.go
@@ -13,19 +13,19 @@ import (
 func (s *server) RoomWSHandler(router *gin.RouterGroup, baseURL string) {
 	router.GET(baseURL+":room_id/ws/", func(c *gin.Context) {
 		roomID := c.Param("room_id")
-		s.hubLock.Lock()
-		defer s.hubLock.Unlock()
-		if s.hubs[roomID] == nil {
+		s.roomsLock.Lock()
+		defer s.roomsLock.Unlock()
+		if s.rooms[roomID] == nil {
 			if roomID == "neo" && os.Getenv("DEBUG") != "" { // TODO temp hardcoded
-				s.hubLock.Unlock()
-				s.hubs[roomID] = s.RoomCreate(roomID)
-				s.hubLock.Lock()
+				s.roomsLock.Unlock()
+				s.rooms[roomID] = s.RoomCreate(roomID)
+				s.roomsLock.Lock()
 			} else {
 				c.JSON(http.StatusUnauthorized, nil)
 				return
 			}
 		}
-		hub := s.hubs[roomID]
+		room := s.rooms[roomID]
 
 		upgrader := websocket.Upgrader{
 			ReadBufferSize:  8192,
@@ -36,7 +36,7 @@ func (s *server) RoomWSHandler(router *gin.RouterGroup, baseURL string) {
 		if err != nil {
 			log.Println(err)
 		}
-		hub.NewClient(conn)
+		room.NewClient(conn)
 	})
 
 }

--- a/room/urls.go
+++ b/room/urls.go
@@ -2,11 +2,10 @@ package room
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/ray1422/YAM-api/room/signaling"
 )
 
 // RegisterRouter RegisterRouter
-func RegisterRouter(roomGroup *gin.RouterGroup) {
-	roomViews(roomGroup, "/")
-	signaling.RoomWSHandler(roomGroup, "/")
+func RegisterRouter(roomGroup *gin.RouterGroup, r HubModel) {
+	v := view{hubModel: r}
+	v.Views(roomGroup, "/")
 }

--- a/room/urls.go
+++ b/room/urls.go
@@ -8,5 +8,5 @@ import (
 // RegisterRouter RegisterRouter
 func RegisterRouter(roomGroup *gin.RouterGroup) {
 	roomViews(roomGroup, "/")
-	signaling.RoomWS(roomGroup, "/")
+	signaling.RoomWSHandler(roomGroup, "/")
 }

--- a/room/urls.go
+++ b/room/urls.go
@@ -5,7 +5,7 @@ import (
 )
 
 // RegisterRouter RegisterRouter
-func RegisterRouter(roomGroup *gin.RouterGroup, r HubModel) {
+func RegisterRouter(roomGroup *gin.RouterGroup, r Hub) {
 	v := view{hubModel: r}
 	v.Views(roomGroup, "/")
 }

--- a/room/urls.go
+++ b/room/urls.go
@@ -6,6 +6,6 @@ import (
 
 // RegisterRouter RegisterRouter
 func RegisterRouter(roomGroup *gin.RouterGroup, r Hub) {
-	v := view{hubModel: r}
+	v := view{hub: r}
 	v.Views(roomGroup, "/")
 }

--- a/room/views.go
+++ b/room/views.go
@@ -14,7 +14,7 @@ type roomIDPost struct {
 }
 
 type view struct {
-	hubModel HubModel
+	hubModel Hub
 }
 
 type View interface {

--- a/room/views.go
+++ b/room/views.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/xid"
 )
 
-type roomIDPOST struct {
+type roomIDPost struct {
 	Password string `json:"password,omitempty"`
 }
 
@@ -38,16 +38,13 @@ func roomViews(roomGroup *gin.RouterGroup, baseURL string) {
 		roomID, _ := c.Params.Get("room_id")
 		_ = roomID
 		// TODO verify roomID
-		body := roomIDPOST{}
+		body := roomIDPost{}
 		c.BindJSON(&body)
 		// TODO AUTH
 		// TODO impl jwt pair (token & refresh)
-		signaling.GlobalHubsLock.Lock()
-		if signaling.Hubs[roomID] == nil {
-			signaling.Hubs[roomID] = signaling.CreateHub(roomID)
-		}
 
-		signaling.GlobalHubsLock.Unlock()
+		signaling.CreateHub(roomID)
+
 		token := jwt.New(48 * time.Hour)
 		token.Payload["room_id"] = roomID
 		c.JSON(http.StatusOK, map[string]interface{}{"token": token.TokenString(), "refresh": "EXAMPLE_REFRESH"})

--- a/room/views.go
+++ b/room/views.go
@@ -14,18 +14,19 @@ type roomIDPost struct {
 }
 
 type view struct {
-	hubModel Hub
+	hub Hub
 }
 
+// View provide the interface that allows registering views to the router
 type View interface {
 	Views(roomGroup *gin.RouterGroup, baseURL string)
 }
 
 func (r view) Views(roomGroup *gin.RouterGroup, baseURL string) {
-	r.hubModel.handleWS(roomGroup, "/")
+	r.hub.handleWS(roomGroup, "/")
 	roomGroup.GET(baseURL, func(c *gin.Context) {
 		// TODO authorization
-		c.JSON(http.StatusOK, r.hubModel.roomList())
+		c.JSON(http.StatusOK, r.hub.roomList())
 		// TODO Pagination
 	})
 	roomGroup.POST(baseURL, func(c *gin.Context) {
@@ -35,7 +36,7 @@ func (r view) Views(roomGroup *gin.RouterGroup, baseURL string) {
 		roomID, _ := c.Params.Get("room_id")
 		_ = roomID
 		// TODO verify roomID
-		info, err := r.hubModel.roomInfo(roomID)
+		info, err := r.hub.roomInfo(roomID)
 		if err != nil {
 			c.JSON(http.StatusNotFound, nil)
 			return
@@ -51,7 +52,7 @@ func (r view) Views(roomGroup *gin.RouterGroup, baseURL string) {
 		// TODO AUTH
 		// TODO impl jwt pair (token & refresh)
 
-		r.hubModel.roomCreate(roomID)
+		r.hub.roomCreate(roomID)
 
 		token := jwt.New(48 * time.Hour)
 		token.Payload["room_id"] = roomID


### PR DESCRIPTION
Remove Lock and Hubs public access, and managing the life-cycle within the package instead.
`hub` is now `room` and `room` is now `hub`.